### PR TITLE
Fix Inkscape download link

### DIFF
--- a/Geartrain-challenge/README.md
+++ b/Geartrain-challenge/README.md
@@ -31,5 +31,5 @@
 
 ![Settings](./img/Gear-settings-inkscape-gear-generator.jpg)
 
-[Download InkScape](www.inkscape.org)
+[Download InkScape](https://inkscape.org/en/download/)
 


### PR DESCRIPTION
Noticed a dead link in the Geartrain Challenge's README.md